### PR TITLE
add setAllowedOrigins(*) for all tutorial examples

### DIFF
--- a/kurento-chroma/src/main/java/org/kurento/tutorial/chroma/ChromaApp.java
+++ b/kurento-chroma/src/main/java/org/kurento/tutorial/chroma/ChromaApp.java
@@ -48,7 +48,7 @@ public class ChromaApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/chroma");
+    registry.addHandler(handler(), "/chroma").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-crowddetector/src/main/java/org/kurento/demo/CrowdDetectorApp.java
+++ b/kurento-crowddetector/src/main/java/org/kurento/demo/CrowdDetectorApp.java
@@ -77,7 +77,7 @@ public class CrowdDetectorApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/crowddetector");
+    registry.addHandler(handler(), "/crowddetector").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-group-call/src/main/java/org/kurento/tutorial/groupcall/GroupCallApp.java
+++ b/kurento-group-call/src/main/java/org/kurento/tutorial/groupcall/GroupCallApp.java
@@ -58,6 +58,6 @@ public class GroupCallApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(groupCallHandler(), "/groupcall");
+    registry.addHandler(groupCallHandler(), "/groupcall").setAllowedOrigins("*");
   }
 }

--- a/kurento-hello-world-recording/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
+++ b/kurento-hello-world-recording/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
@@ -44,7 +44,7 @@ public class HelloWorldRecApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/helloworld");
+    registry.addHandler(handler(), "/helloworld").setAllowedOrigins("*");
   }
 
   @Bean

--- a/kurento-hello-world-repository/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
+++ b/kurento-hello-world-repository/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
@@ -52,7 +52,7 @@ public class HelloWorldRecApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/helloworld");
+    registry.addHandler(handler(), "/helloworld").setAllowedOrigins("*");
   }
 
   @Bean

--- a/kurento-hello-world/src/main/java/org/kurento/tutorial/helloworld/HelloWorldApp.java
+++ b/kurento-hello-world/src/main/java/org/kurento/tutorial/helloworld/HelloWorldApp.java
@@ -45,7 +45,7 @@ public class HelloWorldApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/helloworld");
+    registry.addHandler(handler(), "/helloworld").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-magic-mirror/src/main/java/org/kurento/tutorial/magicmirror/MagicMirrorApp.java
+++ b/kurento-magic-mirror/src/main/java/org/kurento/tutorial/magicmirror/MagicMirrorApp.java
@@ -47,7 +47,7 @@ public class MagicMirrorApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/magicmirror");
+    registry.addHandler(handler(), "/magicmirror").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-metadata-example/src/main/java/org/kurento/tutorial/metadata/MetadataApp.java
+++ b/kurento-metadata-example/src/main/java/org/kurento/tutorial/metadata/MetadataApp.java
@@ -48,7 +48,7 @@ public class MetadataApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/metadata");
+    registry.addHandler(handler(), "/metadata").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-one2many-call/src/main/java/org/kurento/tutorial/one2manycall/One2ManyCallApp.java
+++ b/kurento-one2many-call/src/main/java/org/kurento/tutorial/one2manycall/One2ManyCallApp.java
@@ -45,7 +45,7 @@ public class One2ManyCallApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(callHandler(), "/call");
+    registry.addHandler(callHandler(), "/call").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-one2one-call-advanced/src/main/java/org/kurento/tutorial/one2onecalladv/One2OneCallAdvApp.java
+++ b/kurento-one2one-call-advanced/src/main/java/org/kurento/tutorial/one2onecalladv/One2OneCallAdvApp.java
@@ -53,7 +53,7 @@ public class One2OneCallAdvApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(callHandler(), "/call");
+    registry.addHandler(callHandler(), "/call").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-one2one-call/src/main/java/org/kurento/tutorial/one2onecall/One2OneCallApp.java
+++ b/kurento-one2one-call/src/main/java/org/kurento/tutorial/one2onecall/One2OneCallApp.java
@@ -51,7 +51,7 @@ public class One2OneCallApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(callHandler(), "/call");
+    registry.addHandler(callHandler(), "/call").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-platedetector/src/main/java/org/kurento/tutorial/platedetector/PlateDetectorApp.java
+++ b/kurento-platedetector/src/main/java/org/kurento/tutorial/platedetector/PlateDetectorApp.java
@@ -46,7 +46,7 @@ public class PlateDetectorApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/platedetector");
+    registry.addHandler(handler(), "/platedetector").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-player/src/main/java/org/kurento/tutorial/player/PlayerApp.java
+++ b/kurento-player/src/main/java/org/kurento/tutorial/player/PlayerApp.java
@@ -45,7 +45,7 @@ public class PlayerApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/player");
+    registry.addHandler(handler(), "/player").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-pointerdetector/src/main/java/org/kurento/tutorial/pointerdetector/PointerDetectorApp.java
+++ b/kurento-pointerdetector/src/main/java/org/kurento/tutorial/pointerdetector/PointerDetectorApp.java
@@ -46,7 +46,7 @@ public class PointerDetectorApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/pointerdetector");
+    registry.addHandler(handler(), "/pointerdetector").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-send-data-channel/src/main/java/org/kurento/tutorial/senddatachannel/SendDataChannelApp.java
+++ b/kurento-send-data-channel/src/main/java/org/kurento/tutorial/senddatachannel/SendDataChannelApp.java
@@ -48,7 +48,7 @@ public class SendDataChannelApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/senddatachannel");
+    registry.addHandler(handler(), "/senddatachannel").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-show-data-channel/src/main/java/org/kurento/tutorial/showdatachannel/ShowDataChannelApp.java
+++ b/kurento-show-data-channel/src/main/java/org/kurento/tutorial/showdatachannel/ShowDataChannelApp.java
@@ -48,7 +48,7 @@ public class ShowDataChannelApp implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(handler(), "/showdatachannel");
+    registry.addHandler(handler(), "/showdatachannel").setAllowedOrigins("*");
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
add setAllowedOrigins(*) for all tutorial examples with registerWebSocketHandlers override to allow websocket tunneling for wss.  The Chrome browser now requires HTTPS in order to succeed with a "getUserMedia" call, thus websockets must run over wss.  In order to get wss forwarding to work with the registerWebSocketHandlers override, setAllowedOrigins("*") needs to be called.