### PR TITLE
Increase max text message buffer size for websocket connections

### DIFF
--- a/kurento-chroma/src/main/java/org/kurento/tutorial/chroma/ChromaApp.java
+++ b/kurento-chroma/src/main/java/org/kurento/tutorial/chroma/ChromaApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Chroma main class.
@@ -46,6 +47,13 @@ public class ChromaApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-crowddetector/src/main/java/org/kurento/demo/CrowdDetectorApp.java
+++ b/kurento-crowddetector/src/main/java/org/kurento/demo/CrowdDetectorApp.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * CrowdDetector with RTSP media source (application and media logic).
@@ -75,6 +76,13 @@ public class CrowdDetectorApp implements WebSocketConfigurer {
   @Bean
   public CrowdDetectorHandler handler() {
     return new CrowdDetectorHandler();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-group-call/src/main/java/org/kurento/tutorial/groupcall/GroupCallApp.java
+++ b/kurento-group-call/src/main/java/org/kurento/tutorial/groupcall/GroupCallApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  *
@@ -52,6 +53,13 @@ public class GroupCallApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   public static void main(String[] args) throws Exception {

--- a/kurento-hello-world-recording/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
+++ b/kurento-hello-world-recording/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Hello World (WebRTC in loopback with recording) main class.
@@ -42,6 +43,13 @@ public class HelloWorldRecApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-hello-world-repository/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
+++ b/kurento-hello-world-repository/src/main/java/org/kurento/tutorial/helloworld/HelloWorldRecApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * WebRTC in loopback with recording in repository capabilities main class.
@@ -49,6 +50,13 @@ public class HelloWorldRecApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-hello-world/src/main/java/org/kurento/tutorial/helloworld/Application.java
+++ b/kurento-hello-world/src/main/java/org/kurento/tutorial/helloworld/Application.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Kurento Java Tutorial - Application entry point.
@@ -41,6 +42,13 @@ public class Application implements WebSocketConfigurer
   public KurentoClient kurentoClient()
   {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-magic-mirror/src/main/java/org/kurento/tutorial/magicmirror/MagicMirrorApp.java
+++ b/kurento-magic-mirror/src/main/java/org/kurento/tutorial/magicmirror/MagicMirrorApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Magic Mirror main class.
@@ -45,6 +46,13 @@ public class MagicMirrorApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-metadata-example/src/main/java/org/kurento/tutorial/metadata/MetadataApp.java
+++ b/kurento-metadata-example/src/main/java/org/kurento/tutorial/metadata/MetadataApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Magic Mirror main class.
@@ -46,6 +47,13 @@ public class MetadataApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-one2many-call/src/main/java/org/kurento/tutorial/one2manycall/One2ManyCallApp.java
+++ b/kurento-one2many-call/src/main/java/org/kurento/tutorial/one2manycall/One2ManyCallApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Video call 1 to N demo (main).
@@ -43,6 +44,13 @@ public class One2ManyCallApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-one2one-call-advanced/src/main/java/org/kurento/tutorial/one2onecalladv/One2OneCallAdvApp.java
+++ b/kurento-one2one-call-advanced/src/main/java/org/kurento/tutorial/one2onecalladv/One2OneCallAdvApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Video call 1 to 1 demo (main).
@@ -51,6 +52,13 @@ public class One2OneCallAdvApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-one2one-call-recording/src/main/java/org/kurento/tutorial/one2onecallrec/One2OneCallRecApp.java
+++ b/kurento-one2one-call-recording/src/main/java/org/kurento/tutorial/one2onecallrec/One2OneCallRecApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Video call 1 to 1 demo (main).
@@ -49,6 +50,13 @@ public class One2OneCallRecApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-one2one-call/src/main/java/org/kurento/tutorial/one2onecall/One2OneCallApp.java
+++ b/kurento-one2one-call/src/main/java/org/kurento/tutorial/one2onecall/One2OneCallApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Video call 1 to 1 demo (main).
@@ -49,6 +50,13 @@ public class One2OneCallApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-platedetector/src/main/java/org/kurento/tutorial/platedetector/PlateDetectorApp.java
+++ b/kurento-platedetector/src/main/java/org/kurento/tutorial/platedetector/PlateDetectorApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Plate Detector main class.
@@ -44,6 +45,13 @@ public class PlateDetectorApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-player/src/main/java/org/kurento/tutorial/player/PlayerApp.java
+++ b/kurento-player/src/main/java/org/kurento/tutorial/player/PlayerApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Play of a video through WebRTC (main).
@@ -43,6 +44,13 @@ public class PlayerApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-pointerdetector/src/main/java/org/kurento/tutorial/pointerdetector/PointerDetectorApp.java
+++ b/kurento-pointerdetector/src/main/java/org/kurento/tutorial/pointerdetector/PointerDetectorApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Pointer Detector main class.
@@ -44,6 +45,13 @@ public class PointerDetectorApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-rtp-receiver/src/main/java/org/kurento/tutorial/rtpreceiver/Application.java
+++ b/kurento-rtp-receiver/src/main/java/org/kurento/tutorial/rtpreceiver/Application.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Kurento Java Tutorial - Main Application class.
@@ -41,6 +42,13 @@ public class Application implements WebSocketConfigurer
   public KurentoClient kurentoClient()
   {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-send-data-channel/src/main/java/org/kurento/tutorial/senddatachannel/SendDataChannelApp.java
+++ b/kurento-send-data-channel/src/main/java/org/kurento/tutorial/senddatachannel/SendDataChannelApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Show Data Channel main class.
@@ -46,6 +47,13 @@ public class SendDataChannelApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override

--- a/kurento-show-data-channel/src/main/java/org/kurento/tutorial/showdatachannel/ShowDataChannelApp.java
+++ b/kurento-show-data-channel/src/main/java/org/kurento/tutorial/showdatachannel/ShowDataChannelApp.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 /**
  * Show Data Channel main class.
@@ -46,6 +47,13 @@ public class ShowDataChannelApp implements WebSocketConfigurer {
   @Bean
   public KurentoClient kurentoClient() {
     return KurentoClient.create();
+  }
+
+  @Bean
+  public ServletServerContainerFactoryBean createServletServerContainerFactoryBean() {
+    ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+    container.setMaxTextMessageBufferSize(32768);
+    return container;
   }
 
   @Override


### PR DESCRIPTION
## What is the current behavior you want to change?
This change resolves an issue with WebSocket connections between the browser and the Java application server. The WS connection was closing immediately in Chrome and, when connecting over the nextwork, in Firefox. See https://groups.google.com/d/topic/kurento/f2TRN2TIRwM/discussion for more details.

## What is the new behavior provided by this change?
Increasing the size of the WebSocket text buffer resolves the error.


## How has this been tested?
I've tested the following examples in Chrome and Firefox:
* `kurento-hello-world`
* `kurento-group-call`
* `kurento-one2many-call`

This also resolved the same websocket issue for another developer in `kurento-magic-mirror`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature / enhancement (non-breaking change which improves the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] My change requires a change to the documentation
- [ ] My change requires a change in other repository <!-- Explain which one -->


## Checklist
- [x] I have read the Contribution Guidelines <!-- https://github.com/Kurento/.github/blob/master/CONTRIBUTING.md -->
- [x] I have added an explanation of what the changes do and why they should be included
- [x] I have written new tests for the changes, as applicable, and have successfully run them locally
