### PR TITLE
Specify SSL cipher-suits and enable http2

### DIFF
--- a/kurento-chroma/src/main/resources/application.properties
+++ b/kurento-chroma/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-crowddetector/src/main/resources/application.properties
+++ b/kurento-crowddetector/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-group-call/src/main/resources/application.properties
+++ b/kurento-group-call/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-hello-world-recording/src/main/resources/application.properties
+++ b/kurento-hello-world-recording/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-hello-world-repository/src/main/resources/application.properties
+++ b/kurento-hello-world-repository/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-hello-world/src/main/resources-filtered/application.properties
+++ b/kurento-hello-world/src/main/resources-filtered/application.properties
@@ -36,3 +36,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-magic-mirror/src/main/resources/application.properties
+++ b/kurento-magic-mirror/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-metadata-example/src/main/resources/application.properties
+++ b/kurento-metadata-example/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-one2many-call/src/main/resources/application.properties
+++ b/kurento-one2many-call/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-one2one-call-advanced/src/main/resources/application.properties
+++ b/kurento-one2one-call-advanced/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-one2one-call-recording/src/main/resources/application.properties
+++ b/kurento-one2one-call-recording/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-one2one-call/src/main/resources/application.properties
+++ b/kurento-one2one-call/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-platedetector/src/main/resources/application.properties
+++ b/kurento-platedetector/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-player/src/main/resources/application.properties
+++ b/kurento-player/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-pointerdetector/src/main/resources/application.properties
+++ b/kurento-pointerdetector/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-rtp-receiver/src/main/resources/application.properties
+++ b/kurento-rtp-receiver/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-send-data-channel/src/main/resources/application.properties
+++ b/kurento-send-data-channel/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384

--- a/kurento-show-data-channel/src/main/resources/application.properties
+++ b/kurento-show-data-channel/src/main/resources/application.properties
@@ -35,3 +35,5 @@ server.ssl.key-store=classpath:keystore.jks
 server.ssl.key-store-password=kurento
 server.ssl.key-store-type=JKS
 server.ssl.key-alias=kurento-selfsigned
+server.http2.enabled=true
+server.ssl.ciphers=ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384


### PR DESCRIPTION
I had an issue connecting to the app via Vodafone SIM cards. It seems the network made it not possible to connect to my app. I spend many days on research and finally found the reason for the issue. Adding these lines in application.properties fixes this issue and does not influence the connectivity from other networks. I documentated the issue here: https://stackoverflow.com/questions/62492639/spring-boot-web-tomcat-refusing-connection-for-specific-network-vodafone

This might help other people who uses this as fundament for their app. 